### PR TITLE
Add async interface example from Lamport's Specifying Systems

### DIFF
--- a/HasCal.cabal
+++ b/HasCal.cabal
@@ -34,11 +34,14 @@ test-suite tasty
     main-is:          Main.hs
     build-depends:    base >=4.14.3.0 && < 5
                     , HasCal
+                    , QuickCheck
                     , tasty
                     , tasty-expected-failure
                     , tasty-hunit
                     , tasty-discover
-    other-modules:    HasCal.Test.EuclidAlg
+                    , tasty-quickcheck
+    other-modules:    HasCal.Test.AsyncInterface
+                    , HasCal.Test.EuclidAlg
                     , HasCal.Test.FastMutex
     hs-source-dirs:   tasty
     ghc-options:      -Wall

--- a/HasCal.cabal
+++ b/HasCal.cabal
@@ -34,12 +34,10 @@ test-suite tasty
     main-is:          Main.hs
     build-depends:    base >=4.14.3.0 && < 5
                     , HasCal
-                    , QuickCheck
                     , tasty
                     , tasty-expected-failure
                     , tasty-hunit
                     , tasty-discover
-                    , tasty-quickcheck
     other-modules:    HasCal.Test.AsyncInterface
                     , HasCal.Test.EuclidAlg
                     , HasCal.Test.FastMutex

--- a/shell.nix
+++ b/shell.nix
@@ -6,8 +6,8 @@ let
 
   f = { mkDerivation, base, exceptions, hashable, lib
       , list-transformer, microlens-platform, mtl, prettyprinter
-      , profunctors, QuickCheck, safe-exceptions, tasty, tasty-discover
-      , tasty-expected-failure, tasty-hunit, tasty-quickcheck, text
+      , profunctors, safe-exceptions, tasty, tasty-discover
+      , tasty-expected-failure, tasty-hunit, text
       , transformers, unordered-containers
       }:
       mkDerivation {
@@ -20,8 +20,7 @@ let
           unordered-containers
         ];
         testHaskellDepends = [
-          base QuickCheck tasty tasty-discover tasty-expected-failure tasty-hunit
-          tasty-quickcheck
+          base tasty tasty-discover tasty-expected-failure tasty-hunit
         ];
         testToolDepends = [ tasty-discover ];
         description = "Haskell embedding of PlusCal";

--- a/shell.nix
+++ b/shell.nix
@@ -6,9 +6,9 @@ let
 
   f = { mkDerivation, base, exceptions, hashable, lib
       , list-transformer, microlens-platform, mtl, prettyprinter
-      , profunctors, safe-exceptions, tasty, tasty-discover
-      , tasty-expected-failure, tasty-hunit, text, transformers
-      , unordered-containers
+      , profunctors, QuickCheck, safe-exceptions, tasty, tasty-discover
+      , tasty-expected-failure, tasty-hunit, tasty-quickcheck, text
+      , transformers, unordered-containers
       }:
       mkDerivation {
         pname = "HasCal";
@@ -20,7 +20,8 @@ let
           unordered-containers
         ];
         testHaskellDepends = [
-          base tasty tasty-discover tasty-expected-failure tasty-hunit
+          base QuickCheck tasty tasty-discover tasty-expected-failure tasty-hunit
+          tasty-quickcheck
         ];
         testToolDepends = [ tasty-discover ];
         description = "Haskell embedding of PlusCal";

--- a/src/HasCal/Coroutine.hs
+++ b/src/HasCal/Coroutine.hs
@@ -930,7 +930,7 @@ model
                         lift (State.put $! HashSet.insert seenKey seen)
 
                         put $! Timeline
-                            { _processStatus 
+                            { _processStatus
                             , _history = newHistory
                             , _historySet = HashSet.insert historyKey _historySet
                             , _propertyStatus = newPropertyStatus

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -64,10 +64,7 @@ instance Pretty Label where
   pretty = unsafeViaShow
 
 data Data = D1 | D2
-  deriving (Eq, Generic, Hashable, Show)
-
-instance Universe Data where
-  universe = [D1, D2]
+  deriving (Bounded, Enum, Eq, Generic, Hashable, Show, Universe)
 
 instance QC.Arbitrary Data where
   arbitrary = QC.elements universe

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -112,7 +112,9 @@ next =
 send :: d -> Process (Global d) () Label ()
 send d = do
   yield Send
-  await =<< (==) <$> use (global.chan.rdy) <*> use (global.chan.ack)
+  _rdy <- use (global.chan.rdy)
+  _ack <- use (global.chan.ack)
+  await (_rdy == _ack)
   global.chan.val .= d
   global.chan.rdy %= not
 

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -57,7 +57,7 @@ makeLenses ''Global
 instance Show d => Pretty (Chan d) where
   pretty = unsafeViaShow
 
-data Label = Init | Send | Rcv
+data Label d = Init | Send d | Rcv
   deriving (Eq, Generic, Hashable, Show)
 
 instance Pretty Label where

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -107,19 +107,19 @@ next =
 
 send :: d -> Process (Global d) () (Label d) ()
 send d = do
-  yield (Send d)
   _rdy <- use (global.chan.rdy)
   _ack <- use (global.chan.ack)
   await (_rdy == _ack)
+  yield (Send d)
   global.chan.val .= d
   global.chan.rdy %= not
 
 rcv :: Process (Global d) () (Label d) ()
 rcv = do
-  yield Rcv
   _rdy <- use (global.chan.rdy)
   _ack <- use (global.chan.ack)
   await (_rdy /= _ack)
+  yield Rcv
   global.chan.ack %= not
 
 test_asyncInterface :: TestTree

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -101,7 +101,7 @@ init = do
 
 next :: Universe d => Process (Global d) () Label ()
 next =
-  while (pure True) do
+  forever do
     either
       [ existsU send
       , rcv

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -93,11 +93,10 @@ init :: Universe d => Process (Global d) () (Label d) ()
 init = do
   yield Init
   global.chan.ack <~ use (global.chan.rdy)
-  next
+  Monad.forever next
 
 next :: Universe d => Process (Global d) () (Label d) ()
 next =
-  Monad.forever do
     either
       [ existsU send
       , rcv

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -70,12 +70,12 @@ instance QC.Arbitrary Data where
   arbitrary = QC.elements universe
 
 asyncInterface :: Data -> Bool -> Bool -> IO ()
-asyncInterface val0 rdy0 ack0 =
+asyncInterface =
   model defaultOptions{ debug = True, termination = False }
         coroutine property do
-    let _val = val0
-    let _rdy = rdy0
-    let _ack = ack0
+    _val <- fromList universe
+    _rdy <- fromList universe
+    _ack <- fromList universe
     let _chan = Chan{..}
     return Global{..}
   where

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -1,0 +1,131 @@
+{-| This is the "Our second specification of an asynchronous interface" example
+    from p. 30 in "Specifying Systems" by Lamport:
+
+@
+        CONSTANT Data
+        VARIABLE chan
+        TypeInvariant := chan \in [val : Data, rdy : {0,1}, ack : {0, 1}]
+
+        Init := /\ TypeInvariant
+                /\ chan.ack = chan.rdy
+
+        Send(d) := /\ chan.rdy = chan.ack
+                   /\ chan' = [chan EXCEPT !.val = d, !.rdy = 1 - @]
+
+        Rcv := /\ chan.rdy != chan.ack
+               /\ chan' = [chan EXCPT !.ack = 1 - @]
+
+        Next := (\E d \in Data : Send(d)) \/ Rcv
+
+        Spec := Init /\ [][Next]_chan
+@
+
+    The following module is an attempt to translate it to HasCal.
+-}
+
+{-# LANGUAGE BlockArguments  #-}
+{-# LANGUAGE DeriveAnyClass  #-}
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module HasCal.Test.AsyncInterface where
+
+import HasCal
+import Prelude hiding (either, init)
+import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck.Monadic as QC
+import Test.Tasty (TestTree)
+import qualified Test.Tasty.QuickCheck as TastyQC
+
+data Global d = Global { _chan :: Chan d }
+  deriving (Eq, Generic, Hashable, Show)
+
+instance Show d => Pretty (Global d) where
+  pretty = unsafeViaShow
+
+data Chan d = Chan
+  { _val :: d
+  , _rdy :: Bool
+  , _ack :: Bool
+  }
+  deriving (Eq, Generic, Hashable, Show)
+
+makeLenses ''Chan
+makeLenses ''Global
+
+instance Show d => Pretty (Chan d) where
+  pretty = unsafeViaShow
+
+data Label = Init | Send | Rcv
+  deriving (Eq, Generic, Hashable, Show)
+
+instance Pretty Label where
+  pretty = unsafeViaShow
+
+data Data = D1 | D2
+  deriving (Eq, Generic, Hashable, Show)
+
+instance Universe Data where
+  universe = [D1, D2]
+
+instance QC.Arbitrary Data where
+  arbitrary = QC.elements universe
+
+asyncInterface :: Data -> Bool -> Bool -> IO ()
+asyncInterface val0 rdy0 ack0 =
+  model defaultOptions{ debug = True, termination = False }
+        coroutine property do
+    let _val = val0
+    let _rdy = rdy0
+    let _ack = ack0
+    let _chan = Chan{..}
+    return Global{..}
+  where
+    coroutine :: Coroutine (Global Data) Label
+    coroutine = Begin{..}
+      where
+        startingLabel = Init
+
+        startingLocal = ()
+
+        process = init
+
+    property :: Property (Global Data, Label) Bool
+    property = arr predicate
+      where
+        predicate (_global, _label) = True
+
+init :: Universe d => Process (Global d) () Label ()
+init = do
+  yield Init
+  global.chan.ack <~ use (global.chan.rdy)
+  next
+
+next :: Universe d => Process (Global d) () Label ()
+next =
+  while (pure True) do
+    either
+      [ existsU send
+      , rcv
+      ]
+  where
+    existsU p = either (map p universe)
+
+send :: d -> Process (Global d) () Label ()
+send d = do
+  yield Send
+  await =<< (==) <$> use (global.chan.rdy) <*> use (global.chan.ack)
+  global.chan.val .= d
+  global.chan.rdy %= not
+
+rcv :: Process (Global d) () Label ()
+rcv = do
+  yield Rcv
+  await =<< (/=) <$> use (global.chan.rdy) <*> use (global.chan.ack)
+  global.chan.ack %= not
+
+test_asyncInterface :: TestTree
+test_asyncInterface = TastyQC.testProperty "Async interface" $
+  QC.forAll QC.arbitrary $ \(d, rdy0, ack0) ->
+    QC.monadicIO (QC.run (asyncInterface d rdy0 ack0))

--- a/tasty/HasCal/Test/FastMutex.hs
+++ b/tasty/HasCal/Test/FastMutex.hs
@@ -35,7 +35,8 @@ instance Pretty Label where
     pretty = unsafeViaShow
 
 fastMutex :: Int -> IO ()
-fastMutex n = model defaultOptions{ debug = True } coroutines property do
+fastMutex n = model defaultOptions{ debug = True, termination = False }
+                    coroutines property do
     let _x = 0
     let _y = 0
     let _b = [ 1.. n ] |-> \_i -> False
@@ -113,6 +114,6 @@ fastMutex n = model defaultOptions{ debug = True } coroutines property do
 
             ncs
 
-test_fastMutex:: TestTree
+test_fastMutex :: TestTree
 test_fastMutex = HUnit.testCase "Fast mutex algorithm" do
     fastMutex 3


### PR DESCRIPTION
I tried to add a TLA+ example, not sure if it's correct though.

I guess we want some kind of deadlock detection, i.e. in the while loop one of the either branches *must* be taken, when I tried to obviously break that property by adding `await False` at the top of `send` and `rcv` it still passed. I would have expected if `terminating = False` then the deadlock should be detected (I haven't double checked with TLC)?

I guess we could also try to make a property that says: "always eventually alternate between `Send` and `Rcv`", need to think a bit more about how to express that though.