### PR TITLE
Add `HasCal.Test.Market` example

### DIFF
--- a/HasCal.cabal
+++ b/HasCal.cabal
@@ -34,6 +34,7 @@ test-suite tasty
     main-is:          Main.hs
     build-depends:    base >=4.14.3.0 && < 5
                     , HasCal
+                    , containers
                     , tasty
                     , tasty-expected-failure
                     , tasty-hunit
@@ -43,6 +44,7 @@ test-suite tasty
                     , HasCal.Test.Flags
                     , HasCal.Test.FastMutex
                     , HasCal.Test.Hanoi
+                    , HasCal.Test.Market
                     , HasCal.Test.Trade
                     , HasCal.Test.Transfer
     hs-source-dirs:   tasty

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ MoneyInvariant == alice_account + bob_account = account_total
 
 ```haskell
 import Control.Monad (when)
+import Prelude hiding ((.))
 import HasCal
 
 data Global = Global

--- a/src/HasCal.hs
+++ b/src/HasCal.hs
@@ -47,11 +47,13 @@ module HasCal
     , MonadIO(..)
     , Pretty(..)
     , Pretty.unsafeViaShow
+    , Category(..)
     , Arrow(..)
     ) where
 
 import Control.Arrow (Arrow(..))
 import Control.Applicative (Alternative(..))
+import Control.Category (Category(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)

--- a/src/HasCal/Coroutine.hs
+++ b/src/HasCal/Coroutine.hs
@@ -47,6 +47,7 @@ module HasCal.Coroutine
     , (|->)
     , domain
     , range
+    , subset
     , choose
 
     -- * Model checking
@@ -638,6 +639,10 @@ domain = HashMap.keys
 -}
 range :: HashMap key value -> [value]
 range = HashMap.elems
+
+-- | The powerset of a list, like the @SUBSET@ function in TLA+
+subset :: [a] -> [[a]]
+subset = Monad.filterM (\_ -> [False, True])
 
 {-| Find the first matching element, like the @CHOOSE@ function in TLA+ except
     that this will return a `Nothing` instead of throwing an exception

--- a/tasty/HasCal/Test/AsyncInterface.hs
+++ b/tasty/HasCal/Test/AsyncInterface.hs
@@ -33,7 +33,7 @@
 module HasCal.Test.AsyncInterface where
 
 import HasCal
-import Prelude hiding (either, init)
+import Prelude hiding (either, init, (.))
 import Test.Tasty (TestTree)
 
 import qualified Test.Tasty.HUnit as HUnit
@@ -112,7 +112,5 @@ test_asyncInterface = HUnit.testCase "Async interface" do
             , process        = init
             }
 
-        , property =
-            let predicate (_global, _label) = True
-            in  arr predicate
+        , property = pure True
         }

--- a/tasty/HasCal/Test/EuclidAlg.hs
+++ b/tasty/HasCal/Test/EuclidAlg.hs
@@ -12,7 +12,7 @@ module HasCal.Test.EuclidAlg where
 
 import Control.Monad (when)
 import HasCal
-import Prelude hiding (gcd, print)
+import Prelude hiding (gcd, print, (.))
 import Test.Tasty (TestTree)
 
 import qualified Prelude

--- a/tasty/HasCal/Test/FastMutex.hs
+++ b/tasty/HasCal/Test/FastMutex.hs
@@ -11,6 +11,7 @@ import Control.Monad (when)
 import Data.Traversable (for)
 import HasCal
 import Numeric.Natural (Natural)
+import Prelude hiding ((.))
 import Test.Tasty (TestTree)
 
 import qualified Control.Monad    as Monad
@@ -49,7 +50,7 @@ fastMutex n = model defaultModel
     , property =
         let predicate (_, labels) =
                 length (filter (== CriticalSection) labels) <= 1
-        in  arr predicate
+        in  always . arr predicate
     }
   where
     proc :: Int -> Coroutine Global Label
@@ -62,7 +63,7 @@ fastMutex n = model defaultModel
         }
       where
         ncs = do
-            yield CriticalSection
+            yield NonCriticalSection
             start
 
         start :: Process Global () Label a

--- a/tasty/HasCal/Test/Flags.hs
+++ b/tasty/HasCal/Test/Flags.hs
@@ -44,6 +44,7 @@ module HasCal.Test.Flags where
 
 import Control.Monad (forever)
 import HasCal
+import Prelude hiding ((.))
 import Test.Tasty (TestTree)
 
 import qualified Test.Tasty.HUnit as HUnit

--- a/tasty/HasCal/Test/Hanoi.hs
+++ b/tasty/HasCal/Test/Hanoi.hs
@@ -38,6 +38,7 @@ module HasCal.Test.Hanoi where
 
 import Control.Monad (forever)
 import HasCal hiding (to)
+import Prelude hiding ((.))
 import Test.Tasty (TestTree)
 
 import qualified Test.Tasty.HUnit as HUnit
@@ -52,9 +53,7 @@ test_hanoi =
     Failure.expectFailBecause "The original example intentionally fails" do
         HUnit.testCase "Hanoi" do
             model defaultModel
-                { debug = True
-
-                , termination = False
+                { termination = False
 
                 , startingGlobals = do
                     let board :: [[Int]]

--- a/tasty/HasCal/Test/Market.hs
+++ b/tasty/HasCal/Test/Market.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE BlockArguments   #-}
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE DeriveAnyClass   #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-| This example is from the "Example: Arbitrage" section of the "Learn TLA+"
+    guide
+
+> ---- MODULE market ----
+> EXTENDS Integers
+> CONSTANTS Item, MaxPrice, Vendor, MaxActions
+>
+> I == Item
+> V == Vendor
+> P == 1..MaxPrice
+>
+> ValidMarkets == [V \X I -> [buy : P, sell : P]]
+>
+> (* --algorithm market
+> variables market \in ValidMarkets, 
+>           backpack = {}, \* items we have
+>           actions = 0,
+>           profit = 0; 
+>
+> begin
+>   Act:
+>     while actions < MaxActions do
+>       either
+>         Buy:
+>           with v \in V, i \in Item \ backpack do
+>           profit := profit - market[<<v, i>>].sell;
+>           backpack := backpack \union {i};
+>           end with;
+>       or
+>         Sell:
+>           with v \in V, i \in backpack do
+>             profit := profit + market[<<v, i>>].buy;
+>             backpack := backpack \ {i};
+>           end with;
+>       end either;
+>       Loop:
+>         actions := actions + 1;
+>     end while;
+> end algorithm; *)
+>
+> \* Translation
+>
+> NoArbitrage == profit <= 0
+> ====
+
+-}
+module HasCal.Test.Market where
+
+import Data.Set (Set)
+import Prelude hiding ((.))
+import HasCal
+import Test.Tasty (TestTree)
+
+import qualified Control.Monad as Monad
+import qualified Data.Set as Set
+import qualified Test.Tasty.HUnit as HUnit
+import qualified Test.Tasty.ExpectedFailure as Failure
+
+data Item = Ore | Sheep | Brick
+    deriving (Bounded, Enum, Eq, Generic, Hashable, Ord, Show, Universe)
+
+data Vendor = Alice | Bob
+    deriving (Bounded, Enum, Eq, Generic, Hashable, Show, Universe)
+
+data Offer = Offer { _buy :: Int, _sell :: Int }
+    deriving (Eq, Generic, Hashable, Show)
+
+data Global = Global
+    { _market   :: HashMap (Vendor, Item) Offer
+    , _trades   :: HashMap [Item] Item
+    , _backpack :: Set Item
+    , _profit   :: Int
+    } deriving (Eq, Generic, Hashable, Show)
+
+data Label = Act | Buy Int | Sell Int | Trade Int
+    deriving (Eq, Generic, Hashable, Show)
+
+instance Pretty Global where pretty = unsafeViaShow
+instance Pretty Label  where pretty = unsafeViaShow
+
+makeLenses ''Offer
+makeLenses ''Global
+
+arbitrage :: Int -> Int -> IO ()
+arbitrage maxPrice maxActions = do
+    let _I = universe @Item
+    let _V = universe @Vendor
+    let _P = [ 1 .. maxPrice ]
+
+    model defaultModel
+        { startingGlobals = do
+            let _domain = do
+                    v <- _V
+                    i <- _I
+                    return (v, i)
+
+            let _range = do
+                    _buy  <- _P
+                    _sell <- _P
+                    return Offer{..}
+
+            _market <- _domain --> _range
+
+            let maxBuy  = maximum (fmap _buy _market)
+            let minSell = minimum (fmap _sell _market)
+            Monad.guard (maxBuy <= minSell)
+
+            let _backpack = Set.empty
+
+            let _profit = 0
+
+            _trades <- subset _I --> _I
+
+            return Global{..}
+
+        , coroutine = Coroutine
+            { startingLabel = Act
+
+            , startingLocals = pure ()
+
+            , process = Monad.forM_ [ 1 .. maxActions ] \n ->
+                (   do  yield (Buy n)
+                        _backpack <- use (global.backpack)
+                        v <- with _V
+                        i <- with (Set.toList (Set.difference (Set.fromList _I) _backpack))
+                        Just loss <- preuse (global.market.ix (v, i).sell)
+                        global.profit -= loss
+                        global.backpack %= Set.insert i
+                <|> do  yield (Sell n)
+                        _backpack <- use (global.backpack)
+                        v <- with _V
+                        i <- with (Set.toList _backpack)
+                        Just gain <- preuse (global.market.ix (v, i).buy)
+                        global.profit += gain
+                        global.backpack %= Set.delete i
+                <|> do  yield (Trade n)
+                        _backpack <- use (global.backpack)
+                        _trades <- use (global.trades)
+                        itemsLost <- with (Set.toList (Set.intersection (Set.fromList (subset (Set.toList _backpack))) (Set.fromList (domain _trades))))
+                        Just itemGained <- preuse (global.trades.ix itemsLost)
+                        global.backpack %= Set.insert itemGained . (`Set.difference` (Set.fromList itemsLost))
+                )
+            }
+
+        , property =
+            let predicate (Global{..}, _) = _profit <= 0
+            in  always . arr predicate
+        }
+
+test_market :: TestTree
+test_market =
+    Failure.expectFailBecause "The original example has a deliberate failure" do
+        HUnit.testCase "Market" do
+            arbitrage 6 5

--- a/tasty/HasCal/Test/Trade.hs
+++ b/tasty/HasCal/Test/Trade.hs
@@ -32,6 +32,7 @@ module HasCal.Test.Trade where
 import Control.Monad (when)
 import Data.Foldable (traverse_)
 import HasCal hiding (to)
+import Prelude hiding ((.))
 import Test.Tasty (TestTree)
 
 import qualified Test.Tasty.HUnit as HUnit

--- a/tasty/HasCal/Test/Transfer.hs
+++ b/tasty/HasCal/Test/Transfer.hs
@@ -35,6 +35,7 @@ module HasCal.Test.Transfer where
 
 import Control.Monad (when)
 import HasCal
+import Prelude hiding ((.))
 import Test.Tasty (TestTree)
 
 import qualified Test.Tasty.HUnit as HUnit
@@ -74,7 +75,7 @@ test_transfer =
                 , property =
                     let predicate (Global{..}, _) =
                             _alice_account + _bob_account == _account_total
-                    in  arr predicate
+                    in  always . arr predicate
                 }
   where
     transfer :: Int -> Coroutine Global Label


### PR DESCRIPTION
… and also fix other examples to use `always` for invariants

This caught a bug in the `FastMutex` example